### PR TITLE
Only check server_name when reply type is not NONE

### DIFF
--- a/src/x11rb.rs
+++ b/src/x11rb.rs
@@ -186,9 +186,11 @@ impl<C: HasConnection> X11rbServer<C> {
 
         let mut found = false;
 
-        for prop in reply.value32().ok_or(ServerError::InvalidReply)? {
-            if prop == server_name {
-                found = true;
+        if reply.type_ != x11rb::NONE {
+            for prop in reply.value32().ok_or(ServerError::InvalidReply)? {
+                if prop == server_name {
+                    found = true;
+                }
             }
         }
 


### PR DESCRIPTION
Fix #23 