### PR TITLE
Remove the dependency on libstd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,6 +8,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
 dependencies = [
+ "const-random",
  "getrandom",
  "once_cell",
  "version_check",
@@ -15,9 +16,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
 dependencies = [
  "memchr",
 ]
@@ -56,9 +57,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bstr"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
  "lazy_static",
  "memchr",
@@ -68,18 +69,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.7.0"
+version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
+checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
 name = "cast"
-version = "0.2.7"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
-dependencies = [
- "rustc_version",
-]
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -95,13 +93,35 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "bitflags",
  "textwrap",
  "unicode-width",
+]
+
+[[package]]
+name = "const-random"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acf7ab93790ae0eac37744aff15866e9e3dcc31515d7bf34a6d0fc6c9726b564"
+dependencies = [
+ "const-random-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c6495bfab021aa116773c3e215be28cee0604417ea358f49966fba050c40d9c"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "proc-macro-hack",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -112,9 +132,9 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "criterion"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
+checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
 dependencies = [
  "atty",
  "cast",
@@ -138,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
+checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
 dependencies = [
  "cast",
  "itertools",
@@ -148,9 +168,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -158,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -169,26 +189,31 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.5"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+checksum = "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348"
 dependencies = [
+ "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "lazy_static",
  "memoffset",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
 dependencies = [
  "cfg-if",
- "lazy_static",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "csv"
@@ -198,7 +223,7 @@ checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
 dependencies = [
  "bstr",
  "csv-core",
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]
@@ -236,9 +261,9 @@ checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "encoding_rs"
@@ -285,15 +310,21 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "1.7.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hermit-abi"
@@ -320,14 +351,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.10.1"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
@@ -339,10 +370,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
-name = "js-sys"
-version = "0.3.53"
+name = "itoa"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4bf49d50e2961077d9c99f4b7997d770a1114f087c3c2e0069b36c13fc2979d"
+checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+
+[[package]]
+name = "js-sys"
+version = "0.3.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -382,9 +419,9 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
@@ -410,18 +447,18 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -429,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "oorandom"
@@ -456,9 +493,9 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "plotters"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
+checksum = "2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -469,15 +506,15 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d88417318da0eaf0fdcdb51a0ee6c3bed624333bff8f946733049380be67ac1c"
+checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
+checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
 dependencies = [
  "plotters-backend",
 ]
@@ -505,6 +542,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -542,22 +585,21 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "lazy_static",
  "num_cpus",
 ]
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -572,24 +614,15 @@ checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "same-file"
@@ -605,12 +638,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "semver"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "serde"
@@ -644,11 +671,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.67"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f9e390c27c3c0ce8bc5d725f6e4d30a29d26659494aa4b17535f7522c5c950"
+checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
 dependencies = [
- "itoa",
+ "itoa 1.0.4",
  "ryu",
  "serde",
 ]
@@ -678,9 +705,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
@@ -715,6 +742,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"
@@ -761,9 +797,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.76"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce9b1b516211d33767048e5d47fa2a381ed8b76fc48d2ce4aa39877f9f183e0"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -771,13 +807,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.76"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe8dc78e2326ba5f845f4b5bf548401604fa20b1dd1d365fb73b6c1d6364041"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -786,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.76"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44468aa53335841d9d6b6c023eaab07c0cd4bddbcfdee3e2bb1e8d2cb8069fef"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -796,9 +832,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.76"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0195807922713af1e67dc66132c7328206ed9766af3858164fb583eedc25fbad"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -809,15 +845,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.76"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdb075a845574a1fa5f09fd77e43f7747599301ea3417a9fbffdeedfc1f4a29"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "web-sys"
-version = "0.3.53"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224b2f6b67919060055ef1a67807367c2066ed520c3862cc013d26cf893a783c"
+checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -894,6 +930,7 @@ version = "0.1.2"
 dependencies = [
  "ahash",
  "criterion",
+ "hashbrown 0.12.3",
  "log",
  "pretty_env_logger",
  "thiserror",
@@ -908,7 +945,6 @@ name = "xim-ctext"
 version = "0.2.0"
 dependencies = [
  "encoding_rs",
- "thiserror",
 ]
 
 [[package]]
@@ -926,7 +962,6 @@ version = "0.1.1"
 dependencies = [
  "bitflags",
  "pretty_assertions",
- "thiserror",
  "xim-ctext",
  "xim-gen",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,26 +722,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "283d5230e63df9608ac7d9691adc1dfb6e701225436eb64d0b9a7f0a5a04f6ec"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa3884228611f5cd3608e2d409bf7dce832e4eb3135e3f11addbd7e41bd68e71"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,7 +913,6 @@ dependencies = [
  "hashbrown 0.12.3",
  "log",
  "pretty_env_logger",
- "thiserror",
  "x11-dl",
  "x11rb",
  "xim-ctext",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,28 +16,31 @@ edition = "2018"
 license = "MIT"
 
 [features]
-default = ["x11rb-client"]
+default = ["x11rb-client", "std"]
 
 bootstrap-parser = ["xim-parser/bootstrap"]
 
 client = []
 server = []
 
-x11rb-client = ["client", "x11rb"]
-xlib-client = ["client", "x11-dl"]
+std = ["xim-parser/std", "xim-ctext/std", "ahash/std"]
 
-x11rb-server = ["server", "x11rb"]
-x11rb-xcb = ["x11rb/allow-unsafe-code"]
+x11rb-client = ["client", "x11rb", "std"]
+xlib-client = ["client", "x11-dl", "std"]
+
+x11rb-server = ["server", "x11rb", "std"]
+x11rb-xcb = ["x11rb/allow-unsafe-code", "std"]
 
 [dependencies]
-xim-parser = { path = "./xim-parser", version = "0.1.1" }
-xim-ctext = { path = "./xim-ctext", version = "0.2.0" }
-thiserror = "1.0.28"
-log = "0.4.14"
-ahash = "0.7.4"
+xim-parser = { path = "./xim-parser", version = "0.1.1", default-features = false }
+xim-ctext = { path = "./xim-ctext", version = "0.2.0", default-features = false }
+thiserror = { version = "1.0.28", optional = true }
+log = { version = "0.4.14", default-features = false }
+ahash = { version = "0.7.4", default-features = false, features = ["compile-time-rng"] }
 
 x11rb = { version = "0.9.0", optional = true }
 x11-dl = { version = "2.18.5", optional = true }
+hashbrown = { version = "0.12.3", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ x11rb-xcb = ["x11rb/allow-unsafe-code", "std"]
 [dependencies]
 xim-parser = { path = "./xim-parser", version = "0.1.1", default-features = false }
 xim-ctext = { path = "./xim-ctext", version = "0.2.0", default-features = false }
-thiserror = { version = "1.0.28", optional = true }
 log = { version = "0.4.14", default-features = false }
 ahash = { version = "0.7.4", default-features = false, features = ["compile-time-rng"] }
 

--- a/examples/x11rb_client.rs
+++ b/examples/x11rb_client.rs
@@ -1,5 +1,6 @@
 use x11rb::connection::Connection;
 use x11rb::protocol::{xproto::*, Event};
+use xim::ClientError;
 use xim::{x11rb::X11rbClient, Client};
 use xim_parser::ForwardEventFlag;
 

--- a/src/client/attribute_builder.rs
+++ b/src/client/attribute_builder.rs
@@ -1,4 +1,5 @@
-use ahash::AHashMap;
+use crate::AHashMap;
+use alloc::vec::Vec;
 use xim_parser::{Attribute, AttributeName, XimWrite};
 
 pub struct NestedListBuilder<'a> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,10 @@
+#![no_std]
+
+extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
+
 #[cfg(feature = "client")]
 mod client;
 #[cfg(feature = "server")]
@@ -19,7 +26,7 @@ pub use crate::server::{
     InputContext, InputMethod, Server, ServerCore, ServerError, ServerHandler, UserInputContext,
     XimConnection, XimConnections,
 };
-pub use ahash::AHashMap;
+pub type AHashMap<K, V> = hashbrown::HashMap<K, V, ahash::RandomState>;
 pub use xim_parser::*;
 
 #[allow(non_snake_case)]

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -1,7 +1,10 @@
 mod im_vec;
 
-use ahash::AHashMap;
-use std::num::{NonZeroU16, NonZeroU32};
+use crate::AHashMap;
+use alloc::string::String;
+use alloc::vec::Vec;
+use alloc::vec;
+use core::num::{NonZeroU16, NonZeroU32};
 use xim_parser::{
     attrs, Attribute, AttributeName, ErrorCode, ForwardEventFlag, InputStyle, InputStyleList,
     Point, Request, XimWrite,
@@ -618,7 +621,7 @@ pub struct XimConnections<T> {
 impl<T> XimConnections<T> {
     pub fn new() -> Self {
         Self {
-            connections: AHashMap::new(),
+            connections: AHashMap::with_hasher(Default::default()),
         }
     }
 

--- a/src/server/connection/im_vec.rs
+++ b/src/server/connection/im_vec.rs
@@ -1,6 +1,6 @@
-use ahash::AHashMap;
-use std::collections::hash_map::Entry;
-use std::num::NonZeroU16;
+use crate::AHashMap;
+use hashbrown::hash_map::Entry;
+use core::num::NonZeroU16;
 
 pub struct ImVec<T> {
     next: NonZeroU16,
@@ -11,7 +11,7 @@ impl<T> ImVec<T> {
     pub fn new() -> Self {
         Self {
             next: NonZeroU16::new(1).unwrap(),
-            inner: AHashMap::new(),
+            inner: AHashMap::with_hasher(Default::default()),
         }
     }
 
@@ -52,7 +52,7 @@ impl<T> ImVec<T> {
 impl<T> IntoIterator for ImVec<T> {
     type Item = (NonZeroU16, T);
 
-    type IntoIter = std::collections::hash_map::IntoIter<NonZeroU16, T>;
+    type IntoIter = hashbrown::hash_map::IntoIter<NonZeroU16, T>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.inner.into_iter()

--- a/src/x11rb.rs
+++ b/src/x11rb.rs
@@ -1,4 +1,7 @@
 use std::{convert::TryInto, rc::Rc, sync::Arc};
+use alloc::format;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 #[cfg(feature = "x11rb-client")]
 use crate::client::{
@@ -7,7 +10,7 @@ use crate::client::{
 #[cfg(feature = "x11rb-server")]
 use crate::server::{ServerCore, ServerError, ServerHandler, XimConnection, XimConnections};
 #[cfg(feature = "x11rb-client")]
-use ahash::AHashMap;
+use crate::AHashMap;
 #[cfg(feature = "x11rb-client")]
 use xim_parser::{Attr, AttributeName};
 
@@ -185,7 +188,7 @@ impl<C: HasConnection> X11rbServer<C> {
             )?
             .reply()?;
 
-        if reply.type_ != x11rb::NONE && (reply.type_ != AtomEnum::ATOM.into()) {
+        if reply.type_ != x11rb::NONE && (reply.type_ != Into::<u32>::into(AtomEnum::ATOM)) {
             return Err(ServerError::InvalidReply);
         }
 
@@ -457,8 +460,8 @@ impl<C: HasConnection> X11rbClient<C> {
                             atoms,
                             server_atom,
                             server_owner_window: server_owner,
-                            im_attributes: AHashMap::new(),
-                            ic_attributes: AHashMap::new(),
+                            im_attributes: AHashMap::with_hasher(Default::default()),
+                            ic_attributes: AHashMap::with_hasher(Default::default()),
                             im_window: x11rb::NONE,
                             transport_max: 20,
                             client_window,

--- a/src/x11rb.rs
+++ b/src/x11rb.rs
@@ -188,7 +188,7 @@ impl<C: HasConnection> X11rbServer<C> {
             )?
             .reply()?;
 
-        if reply.type_ != x11rb::NONE && (reply.type_ != AtomEnum::ATOM.into()) {
+        if reply.type_ != x11rb::NONE && (reply.type_ != u32::from(AtomEnum::ATOM.into())) {
             return Err(ServerError::InvalidReply);
         }
 

--- a/src/x11rb.rs
+++ b/src/x11rb.rs
@@ -188,7 +188,7 @@ impl<C: HasConnection> X11rbServer<C> {
             )?
             .reply()?;
 
-        if reply.type_ != x11rb::NONE && (reply.type_ != Into::<u32>::into(AtomEnum::ATOM)) {
+        if reply.type_ != x11rb::NONE && (reply.type_ != AtomEnum::ATOM.into()) {
             return Err(ServerError::InvalidReply);
         }
 

--- a/src/xlib.rs
+++ b/src/xlib.rs
@@ -1,9 +1,10 @@
-use ahash::AHashMap;
+use crate::AHashMap;
 use std::ffi::CStr;
 use std::mem::MaybeUninit;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::{convert::TryInto, os::raw::c_long};
+use alloc::vec::Vec;
 
 use crate::{
     client::{handle_request, ClientCore, ClientError, ClientHandler},
@@ -223,8 +224,8 @@ impl<X: XlibRef> XlibClient<X> {
                             transport_max: 0,
                             display,
                             x,
-                            ic_attributes: AHashMap::new(),
-                            im_attributes: AHashMap::new(),
+                            ic_attributes: AHashMap::with_hasher(Default::default()),
+                            im_attributes: AHashMap::with_hasher(Default::default()),
                             buf: Vec::with_capacity(1024),
                             sequence: 0,
                         });
@@ -454,7 +455,7 @@ impl<X: XlibRef> XlibClient<X> {
                 );
             }
         } else {
-            let name = format!("_XIM_DATA_{}\0", self.sequence);
+            let name = alloc::format!("_XIM_DATA_{}\0", self.sequence);
             self.sequence += 1;
             let prop =
                 unsafe { (self.x.xlib().XInternAtom)(self.display, name.as_ptr().cast(), 0) };

--- a/xim-ctext/Cargo.toml
+++ b/xim-ctext/Cargo.toml
@@ -9,4 +9,7 @@ license = "MIT"
 
 [dependencies]
 encoding_rs = "0.8.28"
-thiserror = "1.0.28"
+
+[features]
+default = ["std"]
+std = []

--- a/xim-gen/src/lib.rs
+++ b/xim-gen/src/lib.rs
@@ -94,7 +94,7 @@ impl EnumFormat {
 
         writeln!(
             out,
-            "fn size(&self) -> usize {{ std::mem::size_of::<{}>() }}",
+            "fn size(&self) -> usize {{ core::mem::size_of::<{}>() }}",
             self.repr
         )?;
 
@@ -239,7 +239,7 @@ impl XimFormat {
         for (key, value) in self.attribute_names.iter() {
             writeln!(out, "b\"{}\" => Ok(Self::{}),", value, key)?;
         }
-        writeln!(out, "bytes => Err(reader.invalid_data(\"AttributeName\", std::str::from_utf8(bytes).unwrap_or(\"NOT_UTF8\"))),")?;
+        writeln!(out, "bytes => Err(reader.invalid_data(\"AttributeName\", core::str::from_utf8(bytes).unwrap_or(\"NOT_UTF8\"))),")?;
         // match
         writeln!(out, "}}")?;
         // fn read
@@ -320,7 +320,7 @@ impl XimFormat {
             writeln!(out, "}}),")?;
         }
 
-        writeln!(out, "_ => Err(reader.invalid_data(\"Opcode\", format!(\"({{}}, {{}})\", major_opcode, minor_opcode))),")?;
+        writeln!(out, "_ => Err(reader.invalid_data(\"Opcode\", alloc::format!(\"({{}}, {{}})\", major_opcode, minor_opcode))),")?;
 
         // match
         writeln!(out, "}}")?;

--- a/xim-parser/Cargo.toml
+++ b/xim-parser/Cargo.toml
@@ -8,11 +8,12 @@ edition = "2018"
 license = "MIT"
 
 [features]
+default = ["std"]
+std = []
 bootstrap = ["xim-gen"]
 
 [dependencies]
-thiserror = "1.0.28"
-bitflags = "1.3.2"
+bitflags = { version = "1.3.2", default-features = false }
 
 [dev-dependencies]
 xim-ctext = { path = "../xim-ctext", version = "0.2.0" }

--- a/xim-parser/src/lib.rs
+++ b/xim-parser/src/lib.rs
@@ -1,3 +1,12 @@
+#![no_std]
+
+extern crate alloc;
+
+#[cfg(any(test, feature = "std"))]
+extern crate std;
+
+use alloc::vec::Vec;
+
 pub mod attrs;
 mod parser;
 
@@ -5,12 +14,12 @@ pub use parser::*;
 
 pub fn write_extend_vec(f: impl XimWrite, out: &mut Vec<u8>) {
     let from = out.len();
-    out.extend(std::iter::repeat(0).take(f.size()));
+    out.extend(core::iter::repeat(0).take(f.size()));
     f.write(&mut Writer::new(&mut out[from..]));
 }
 
 pub fn write_to_vec(f: impl XimWrite) -> Vec<u8> {
-    let mut out: Vec<u8> = std::iter::repeat(0).take(f.size()).collect();
+    let mut out: Vec<u8> = core::iter::repeat(0).take(f.size()).collect();
     f.write(&mut Writer::new(&mut out));
     out
 }
@@ -19,6 +28,8 @@ pub fn write_to_vec(f: impl XimWrite) -> Vec<u8> {
 mod tests {
     use crate::{parser::*, write_to_vec};
     use pretty_assertions::assert_eq;
+    use alloc::vec::Vec;
+    use alloc::vec;
 
     #[cfg(target_endian = "little")]
     #[test]


### PR DESCRIPTION
Resolves #35 by removing the dependency on libstd. This does not remove the dependency on liballoc; truth be told I think that's a non-starter. I've verified that this runs on `thumbv7m-none-eabi` with the new `std` feature disabled.

**This is a breaking change.**