### PR TITLE
Clean up various parts of the codebase

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,3 +63,6 @@ pretty_env_logger = "0.4.0"
 [[bench]]
 name = "rw"
 harness = false
+
+[package.metadata.docs.rs]
+all-features = true

--- a/examples/x11rb_client.rs
+++ b/examples/x11rb_client.rs
@@ -37,8 +37,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     log::info!("Start event loop");
 
-    let mut handler = ExampleHandler::default();
-    handler.window = window;
+    let mut handler = ExampleHandler {
+        window,
+        ..ExampleHandler::default()
+    };
 
     loop {
         let e = conn.wait_for_event()?;

--- a/examples/xlib_client.rs
+++ b/examples/xlib_client.rs
@@ -33,8 +33,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         log::info!("Start event loop");
 
-        let mut handler = ExampleHandler::default();
-        handler.window = window as u32;
+        let mut handler = ExampleHandler {
+            window: window as _,
+            ..ExampleHandler::default()
+        };
 
         (xlib.XSelectInput)(display, window, xlib::KeyPressMask | xlib::KeyReleaseMask);
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -162,7 +162,8 @@ pub fn handle_request<C: ClientCore>(
             data,
         } => match data {
             CommitData::Keysym { keysym: _, .. } => {
-                todo!()
+                log::warn!("Keysym commit is not supported");
+                Ok(())
             }
             CommitData::Chars {
                 commited,
@@ -184,7 +185,10 @@ pub fn handle_request<C: ClientCore>(
 
                 Ok(())
             }
-            _ => todo!(),
+            data => {
+                log::warn!("Unknown commit data: {:?}", data);
+                Ok(())
+            }
         },
         Request::Sync {
             input_method_id,
@@ -373,7 +377,7 @@ where
         flag: ForwardEventFlag,
         xev: &Self::XEvent,
     ) -> Result<(), ClientError> {
-        let ev = self.serialize_event(&xev);
+        let ev = self.serialize_event(xev);
         self.send_req(Request::ForwardEvent {
             input_method_id,
             input_context_id,

--- a/src/client.rs
+++ b/src/client.rs
@@ -185,8 +185,8 @@ pub fn handle_request<C: ClientCore>(
 
                 Ok(())
             }
-            data => {
-                log::warn!("Unknown commit data: {:?}", data);
+            CommitData::Both { .. } => {
+                log::warn!("Both commit data is not supported");
                 Ok(())
             }
         },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,29 @@
+//! Implements the X Input Method (XIM) protocol.
+//!
+//! XIM is the input method framework used for X11 applications. To clarify, it provides
+//! a strategy for users of non-English keyboard to type symbols using only keys that are
+//! available on the keyboard. XIM involves two processes. One is the server, which waits
+//! for keyboard input in order to compose it into a symbol. The other is the client, which
+//! is usually a normal X11 application that waits for and acts on XIM events.
+//!
+//! This crate provides the following features:
+//!
+//! - An implementation of an XIM client, via the [`Client`] trait (requires the `client`
+//!   feature).
+//! - An implementation of an XIM server, via the [`Server`] trait (requires the `server`
+//!   feature).
+//! - A wrapper around [`x11rb`](x11rb-library), the X rust bindings. See the [`x11rb`] module
+//!   for more information (requires the `x11rb-client` or `x11rb-server` feature).
+//! - A wrapper around [`x11-dl`](x11dl-library), the standard X11 library. See the [`xlib`]
+//!   module for more information (requires the `xlib-client` feature).
+//!
+//! [x11rb-library]: https://crates.io/crates/x11rb
+//! [x11dl-library]: https://crates.io/crates/x11-dl
+
 #![no_std]
+#![allow(clippy::uninlined_format_args, clippy::too_many_arguments)]
+#![cfg_attr(not(feature = "xlib-client"), forbid(unsafe_code))]
+#![forbid(future_incompatible)]
 
 extern crate alloc;
 

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -102,7 +102,7 @@ fn set_ic_attrs(ic: &mut InputContext, ic_attributes: Vec<Attribute>) {
 
         match name {
             AttributeName::InputStyle => {
-                if let Some(style) = xim_parser::read(&attr.value).ok() {
+                if let Ok(style) = xim_parser::read(&attr.value) {
                     log::debug!("Style: {:?}", style);
                     ic.input_style = style;
                 }
@@ -616,6 +616,12 @@ impl<T> XimConnection<T> {
 
 pub struct XimConnections<T> {
     pub(crate) connections: AHashMap<u32, XimConnection<T>>,
+}
+
+impl<T> Default for XimConnections<T> {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl<T> XimConnections<T> {

--- a/src/x11rb.rs
+++ b/src/x11rb.rs
@@ -1,3 +1,10 @@
+//! Provides an implementation of XIM using [`x11rb`] as a transport.
+//!
+//! Wrap your `Connection` in an [`X11rbClient`] or [`X11rbServer`] and use it as a
+//! client or server.
+//!
+//! [`x11rb`]: https://crates.io/crates/x11rb
+
 use alloc::format;
 use alloc::string::String;
 use alloc::vec::Vec;
@@ -719,7 +726,7 @@ fn send_req_impl<C: HasConnection, E: From<ConnectionError> + From<ReplyError>>(
             AtomEnum::STRING,
             8,
             buf.len() as u32,
-            &buf,
+            buf,
         )?;
         c.conn().send_event(
             false,

--- a/src/xlib.rs
+++ b/src/xlib.rs
@@ -1,3 +1,8 @@
+//! Provides a wrapper around Xlib (through the [`x11-dl`] crate) that allows to use Xlib as a
+//! client for XIM.
+//!
+//! Note that it is generally discouraged to use Xlib in the modern era.
+
 use crate::AHashMap;
 use alloc::vec::Vec;
 use std::ffi::CStr;
@@ -133,8 +138,11 @@ pub struct XlibClient<X: XlibRef> {
 }
 
 impl<X: XlibRef> XlibClient<X> {
+    /// Initialize a new `XlibClient` from an Xlib connection.
+    ///
     /// # Safety
-    /// display must avaliable
+    ///
+    /// The `display` pointer must be a valid Xlib display.
     pub unsafe fn init(
         x: X,
         display: *mut xlib::Display,
@@ -241,8 +249,11 @@ impl<X: XlibRef> XlibClient<X> {
         }
     }
 
+    /// Filter an event and call the handler if it is relevant.
+    ///
     /// # Safety
-    /// e must have valid format
+    ///
+    /// The event `e` must be a valid Xlib event.
     pub unsafe fn filter_event(
         &mut self,
         e: &xlib::XEvent,

--- a/xim-ctext/src/lib.rs
+++ b/xim-ctext/src/lib.rs
@@ -1,6 +1,13 @@
-//! Currently only support utf8 mode
+//! A parser for the compound text encoding used by the X Input Method protocol.
+//!
+//! Currently only support utf8 mode. This is intended to be used as a building block for
+//! higher level libraries. See the [`xim`] crate for an example.
+//!
+//! [xim]: https://crates.io/crates/xim
 
 #![no_std]
+#![allow(clippy::uninlined_format_args)]
+#![forbid(unsafe_code, future_incompatible)]
 
 extern crate alloc;
 
@@ -43,6 +50,10 @@ impl<'s> CText<'s> {
 
     pub const fn len(self) -> usize {
         self.utf8.len() + UTF8_START.len() + UTF8_END.len()
+    }
+
+    pub const fn is_empty(self) -> bool {
+        self.utf8.is_empty()
     }
 
     #[cfg(feature = "std")]

--- a/xim-ctext/src/main.rs
+++ b/xim-ctext/src/main.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::uninlined_format_args)]
 fn dump(s: &str) {
     let b = xim_ctext::utf8_to_compound_text(s);
 
@@ -7,7 +8,7 @@ fn dump(s: &str) {
         print!("{:02}/{:02}({:2X}), ", b / 16, b % 16, b);
     }
 
-    println!("");
+    println!();
 }
 
 fn main() {

--- a/xim-gen/src/format_type.rs
+++ b/xim-gen/src/format_type.rs
@@ -172,7 +172,7 @@ impl<'de> Deserialize<'de> for Field {
     {
         let text = String::deserialize(deserializer)?;
         let pos = text
-            .find(" ")
+            .find(' ')
             .ok_or_else(|| D::Error::custom("Can't parse field"))?;
         let (name, left) = text.split_at(pos);
 
@@ -199,7 +199,7 @@ impl std::str::FromStr for FormatType {
             if left.chars().next().unwrap().is_numeric() {
                 let (num, new_left) = left.split_at(2);
                 left = new_left;
-                let num = num.parse::<usize>().or_else(|_| Err("Invalid number"))?;
+                let num = num.parse::<usize>().map_err(|_| "Invalid number")?;
                 prefix = num / 10;
                 len = num % 10;
             }
@@ -209,7 +209,7 @@ impl std::str::FromStr for FormatType {
             let (n, left) = left.split_at(1);
             Ok(Self::Append(
                 Box::new(left.parse()?),
-                n.parse().or_else(|_| Err("@append need number!"))?,
+                n.parse().map_err(|_| "@append need number!")?,
             ))
         } else if s.starts_with("xstring") {
             Ok(Self::XString)
@@ -228,12 +228,10 @@ impl std::str::FromStr for FormatType {
                 len: 2,
                 between_unused: 0,
             })
+        } else if s.starts_with('@') {
+            Err("Invalid format command")
         } else {
-            if s.starts_with("@") {
-                Err("Invalid format command")
-            } else {
-                Ok(Self::Normal(s.into()))
-            }
+            Ok(Self::Normal(s.into()))
         }
     }
 }

--- a/xim-gen/src/lib.rs
+++ b/xim-gen/src/lib.rs
@@ -1,3 +1,7 @@
+//! The code generator used to create the `xim_parser` crate.
+
+#![allow(clippy::uninlined_format_args)]
+
 use crate::format_type::Field;
 use convert_case::{Case, Casing};
 use serde::Deserialize;
@@ -20,7 +24,7 @@ impl EnumFormat {
     pub fn write(&self, name: &str, out: &mut impl Write) -> io::Result<()> {
         // reorder variants for variant value
         let mut variants = self.variants.iter().collect::<Vec<_>>();
-        variants.sort_unstable_by(|l, r| l.1.cmp(&r.1));
+        variants.sort_unstable_by(|l, r| l.1.cmp(r.1));
 
         if self.bitflag {
             writeln!(out, "bitflags::bitflags! {{")?;

--- a/xim-parser/src/lib.rs
+++ b/xim-parser/src/lib.rs
@@ -1,3 +1,12 @@
+//! A parser for reading and writing the X Input Method protocol.
+//!
+//! This is intended to be used as a building block for higher level libraries. See the
+//! [`xim`] crate for an example.
+//!
+//! [`xim`]: https://crates.io/crates/xim
+
+#![allow(clippy::uninlined_format_args)]
+#![forbid(unsafe_code, future_incompatible)]
 #![no_std]
 
 extern crate alloc;
@@ -203,7 +212,21 @@ mod tests {
             input_context_id: 0,
             flag: ForwardEventFlag::empty(),
             serial_number: 0,
-            xev: unsafe { std::mem::zeroed() },
+            xev: XEvent {
+                response_type: 0,
+                detail: 0,
+                sequence: 0,
+                time: 0,
+                root: 0,
+                event: 0,
+                child: 0,
+                root_x: 0,
+                root_y: 0,
+                event_x: 0,
+                event_y: 0,
+                state: 0,
+                same_screen: false,
+            },
         };
         assert_eq!(req.size(), 4 + 8 + 32);
 

--- a/xim-parser/src/parser.rs
+++ b/xim-parser/src/parser.rs
@@ -362,7 +362,7 @@ impl XimWrite for CommitData {
                 let flag = if *syncronous { 3u16 } else { 2u16 };
                 flag.write(writer);
                 (commited.len() as u16).write(writer);
-                writer.write(commited);
+                writer.write(&commited);
                 writer.write_pad4();
             }
             Self::Keysym { keysym, syncronous } => {
@@ -381,7 +381,7 @@ impl XimWrite for CommitData {
                 0u16.write(writer);
                 keysym.write(writer);
                 (commited.len() as u16).write(writer);
-                writer.write(commited);
+                writer.write(&commited);
                 writer.write_pad4();
             }
         }
@@ -1603,7 +1603,7 @@ impl Request {
             Request::ConnectReply { .. } => "ConnectReply",
             Request::CreateIc { .. } => "CreateIc",
             Request::CreateIcReply { .. } => "CreateIcReply",
-            Request::DestroyIc { .. } => "destroyIc",
+            Request::DestroyIc { .. } => "DestroyIc",
             Request::DestroyIcReply { .. } => "DestroyIcReply",
             Request::Disconnect { .. } => "Disconnect",
             Request::DisconnectReply { .. } => "DisconnectReply",
@@ -2502,7 +2502,7 @@ impl XimWrite for Request {
                 chg_length.write(writer);
                 status.write(writer);
                 (preedit_string.len() as u16).write(writer);
-                writer.write(preedit_string);
+                writer.write(&preedit_string);
                 writer.write_pad4();
                 ((feedbacks.iter().map(|e| e.size()).sum::<usize>() + 2 + 2 - 2 - 2) as u16)
                     .write(writer);
@@ -2618,7 +2618,7 @@ impl XimWrite for Request {
                 input_method_id.write(writer);
                 input_context_id.write(writer);
                 (preedit_string.len() as u16).write(writer);
-                writer.write(preedit_string);
+                writer.write(&preedit_string);
                 writer.write_pad4();
             }
             Request::SetEventMask {


### PR DESCRIPTION
Cleans up various parts of the codebase. This includes:

- `cargo fmt --all`
- Fix a handful of clippy warnings that I found.
- `forbid` some popular lints.
- Add crate-level documentation to each crate.
- Remove a couple of potential panics.