### PR TITLE
chore: Add client handle_forward_event example

### DIFF
--- a/examples/util/handler.rs
+++ b/examples/util/handler.rs
@@ -11,7 +11,9 @@ pub struct ExampleHandler {
     pub window: u32,
 }
 
-impl<C: Client> ClientHandler<C> for ExampleHandler {
+impl<C: Client<XEvent = x11rb::protocol::xproto::KeyPressEvent>> ClientHandler<C>
+    for ExampleHandler
+{
     fn handle_connect(&mut self, client: &mut C) -> Result<(), ClientError> {
         log::trace!("Connected");
         client.open("en_US")
@@ -54,6 +56,18 @@ impl<C: Client> ClientHandler<C> for ExampleHandler {
         self.connected = true;
         self.ic_id = input_context_id;
         log::info!("IC created {}, {}", input_method_id, input_context_id);
+        Ok(())
+    }
+
+    fn handle_forward_event(
+        &mut self,
+        _client: &mut C,
+        _input_method_id: u16,
+        _input_context_id: u16,
+        flag: xim::ForwardEventFlag,
+        xev: C::XEvent,
+    ) -> Result<(), ClientError> {
+        log::info!("Handle forward event {:?}, {}", flag, xev.detail);
         Ok(())
     }
 

--- a/examples/x11rb_client.rs
+++ b/examples/x11rb_client.rs
@@ -1,3 +1,5 @@
+#![feature(trait_alias)]
+
 use x11rb::connection::Connection;
 use x11rb::protocol::{xproto::*, Event};
 use xim::{x11rb::X11rbClient, Client};

--- a/examples/xlib_client.rs
+++ b/examples/xlib_client.rs
@@ -1,3 +1,5 @@
+#![feature(trait_alias)]
+
 use std::{mem::MaybeUninit, ptr};
 use x11_dl::xlib;
 use xim::{xlib::XlibClient, Client};


### PR DESCRIPTION
Added handle_forward_event example on x11rb client example code.
This would help client library users working on IME support.