### PR TITLE
fix: client: Handle fcitx4's empty reply case

### DIFF
--- a/src/xlib.rs
+++ b/src/xlib.rs
@@ -386,6 +386,11 @@ impl<X: XlibRef> XlibClient<X> {
                 let _bytes = bytes.assume_init();
                 let prop = prop.assume_init();
 
+                // handle fcitx4 occasionally sending empty reply
+                if _bytes == 0 {
+                    return Err(ClientError::InvalidReply);
+                }
+
                 let data = std::slice::from_raw_parts(prop, items as usize);
 
                 let req = xim_parser::read(data)?;


### PR DESCRIPTION
Fcitx4 occasionally sends reply with empty value when it gets too much events forwarded.
This patch fixes client to handle that case properly as `ClientError::InvalidReply`.
<details>
<summary>Log screenshot of Fcitx4 empty reply case </summary>
<img src="https://github.com/Riey/xim-rs/assets/113083996/9d6d0ae9-adda-46cb-891d-ccb41a9be88f">
</details>